### PR TITLE
mention the branch param in the readme and error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ go mod edit -replace gopkg.in/yaml.v2=gopkg.in/yaml.v2@v2.4.0
 go mod tidy
 ```
 
-
 ## Installation
 
 1. To install GoGuard, you need to have Go installed on your machine. Once you have Go, you can install GoGuard by running the following command:
@@ -50,17 +49,17 @@ you can run the following command:
 ```bash
 Usage: ./goguard <mode> <GitHub-Repo-URL> <CVE ID>
  -- Modes: cve, go, pkg --
-  Example: goguard cve <GitHub-Repo-URL> <CVE ID>)
-  Example: goguard go <GitHub-Repo-URL> <GOVULN ID>)
-  Example: goguard pkg <GitHub-Repo-URL> <VULNPKG> <VULNVER>)
+  Example: goguard cve <GitHub-Repo-URL> <BRANCH> <CVE ID>)
+  Example: goguard go <GitHub-Repo-URL> <BRANCH> <GOVULN ID>)
+  Example: goguard pkg <GitHub-Repo-URL> <BRANCH> <VULNPKG> <VULNVER>)
 ```
 
 For example:
 
 ```bash
-goguard cve https://github.com/user/repo CVE-2021-4238
-goguard go https://github.com/user/repo GO-2022-0411
-goguard pkg https://github.com/user/repo 'goutils' '1.0'
+goguard cve https://github.com/user/repo main CVE-2021-4238
+goguard go https://github.com/user/repo main GO-2022-0411
+goguard pkg https://github.com/user/repo main 'goutils' '1.0'
 ```
 
 This command will check if the GitHub repository `https://github.com/user/repo` is vulnerable against the CVE `CVE-2021-4238`.

--- a/input.go
+++ b/input.go
@@ -43,15 +43,15 @@ func getMode() (scanMode, error) {
 // it also prints the usage message if the user didn't provide the required arguments
 // it also prints an error message if the user provided an invalid CVE ID or GitHub URL that is not a GitHub URL
 func getUserInputCVEMode() (string, string, string, error) {
-	// this is CVEState: ./goguard cve <GitHub-Repo-URL> <CVE ID>
-	// this is GoState:  ./goguard go <GitHub-Repo-URL> <GOVULN ID>
-	// this is PKGState: ./goguard pkg <GitHub-Repo-URL> <VULNPKG> <VULNVER>
+	// this is CVEState: ./goguard cve <GitHub-Repo-URL> <BRANCH> <CVE ID>
+	// this is GoState:  ./goguard go <GitHub-Repo-URL> <BRANCH> <GOVULN ID>
+	// this is PKGState: ./goguard pkg <GitHub-Repo-URL> <BRANCH> <VULNPKG> <VULNVER>
 
 	var repoURL, branch, cve string
 	var err error
 	// Check if the user has provided the required arguments
 	if len(os.Args) < 5 {
-		err = errors.New(fmt.Sprint("Usage: ", name, " cve <GitHub-Repo-URL> <CVE ID>"))
+		err = errors.New(fmt.Sprint("Usage: ", name, " cve <GitHub-Repo-URL> <BRANCH> <CVE ID>"))
 		return repoURL, branch, cve, err
 	}
 
@@ -117,8 +117,8 @@ func getUserInputGoMode() (string, string, string, error) {
 	var err error
 
 	// Check if the user has provided the required arguments
-	if len(os.Args) < 4 {
-		err = errors.New(fmt.Sprint("Usage: ", name, " go <GitHub-Repo-URL> <GOVULN ID>"))
+	if len(os.Args) < 5 {
+		err = errors.New(fmt.Sprint("Usage: ", name, " go <GitHub-Repo-URL> <BRANCH> <GOVULN ID>"))
 		return repoURL, branch, govuln, err
 	}
 
@@ -147,8 +147,8 @@ func getUserInputPKGMode() (string, string, string, string, error) {
 	var err error
 
 	// Check if the user has provided the required arguments
-	if len(os.Args) < 5 {
-		err = errors.New(fmt.Sprint("Usage: ", name, " pkg <GitHub-Repo-URL> <VULNPKG> <VULNVER>"))
+	if len(os.Args) < 6 {
+		err = errors.New(fmt.Sprint("Usage: ", name, " pkg <GitHub-Repo-URL> <BRANCH> <VULNPKG> <VULNVER>"))
 		return repoURL, branch, vulnpkg, vulnver, err
 	}
 


### PR DESCRIPTION
The input validation was wrong in `go` and `pkg` modes, I believe, and the error messages didn't mention the branch parameter. I also updated the README to include it.